### PR TITLE
Support spatie/opening-hours 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.2|^8.0",
         "laravel/nova": "^4.13",
         "nova-kit/nova-packages-tool": "^1.2",
-        "spatie/opening-hours": "^2.0"
+        "spatie/opening-hours": "^2.0|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Closes #36 

As far as i can tell only needs changing dependency to support both 2.x and 3.x.

https://github.com/spatie/opening-hours/releases/tag/3.0.0